### PR TITLE
Remove 'srcFrom'

### DIFF
--- a/sample/conf/charts/sample-app/values.yaml
+++ b/sample/conf/charts/sample-app/values.yaml
@@ -8,4 +8,3 @@ app:
   args: '["serve-develop"]'
   domain: sample.k3d.localhost
   port: 5000
-  srcFrom: /src


### PR DESCRIPTION
The binary file "serve-develop" is already in the container, mount any more directory at "/app" will overwrite the directory and cause the command "serve-develop" could not be found.