### PR TITLE
fix potential infinite loop by removing dynamic part of filename

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
     image: bitnami/kubectl:1.22.2
     user: root # the bitnami/kubectl image has a non-root user set by default, which does not work with the shared docker volume which is owned by root
     commands:
-      - export KUBECONFIG=kubeconfig-$${DRONE_BUILD_STARTED}.yaml
+      - export KUBECONFIG=kubeconfig.yaml
       - until test -f $${KUBECONFIG}; do sleep 1s; done # wait for k3d service to write the kubeconfig to the workspace
       - kubectl config view
       - kubectl get pods --all-namespaces
@@ -36,6 +36,6 @@ services:
       - until docker ps 2>&1 > /dev/null; do sleep 1s; done # wait for docker to be ready before proceeding
       - k3d cluster create --config ci/k3d-drone.yaml --api-port k3dsvc:6445 # create k3d cluster from config file
       - until kubectl get deployment coredns -n kube-system -o go-template='{{.status.availableReplicas}}' | grep -v -e '<no value>'; do sleep 1s; done # wait for coredns to be up and running
-      - k3d kubeconfig get drone > kubeconfig-$${DRONE_BUILD_STARTED}.yaml
+      - k3d kubeconfig get drone > kubeconfig.yaml
       - printf "@@@@@@@@@@@@@@@@@@@@@@@\n@@@@ k3d is ready! @@@@\n@@@@@@@@@@@@@@@@@@@@@@@\n"
       - tail -f /dev/null # chill around while the steps do their work


### PR DESCRIPTION
More explanation here. https://github.com/k3d-io/k3d-demo/issues/15

This is a suggested fix with a hard-coded filename. If a dynamic filename is needed, other info could be added (e.g. repo namespace and repo name, build number, or maybe just DRONE_COMMIT_SHA).